### PR TITLE
Allow -v option to be passed through to sphinx-build

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 Version 0.1
 ===========
 
+Version 0.1.2
+-------------
+* Added the ability to set verbosity (one or more ``-v`` arguments) when invoking the sphinx build.
+
+
 Version 0.1.1
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://holzhaus.github.io/sphinx-multiversion/",
-    version="0.1.1",
+    version="0.1.2",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -58,6 +58,14 @@ def main(argv=None):
         action="store_true",
         help="dump generated metadata and exit",
     )
+    parser.add_argument(
+        "-v",
+        action="count",
+        dest="verbosity",
+        default=0,
+        help="increase logging verbosity (can be repeated)",
+    )
+
     args, argv = parser.parse_known_args(argv)
     if args.noconfig:
         return 1
@@ -203,6 +211,7 @@ def main(argv=None):
             os.makedirs(outdir, exist_ok=True)
 
             current_argv = argv.copy()
+            current_argv.extend(["-v"] * (args.verbosity - 1))
             current_argv.extend(
                 [
                     *itertools.chain(*(("-D", d) for d in args.define)),


### PR DESCRIPTION
Resolves #5 

Does not internally change the loglevel inside `sphinx-multversion`.  I attempted this, but Sphinx internally overrides the root logger with handlers: https://github.com/sphinx-doc/sphinx/blob/master/sphinx/util/logging.py#L560-L591 , one of which removes all messages that are `INFO` and above: https://github.com/sphinx-doc/sphinx/blob/master/sphinx/util/logging.py#L342-L349