### PR TITLE
Skip git refs without sourcedir or conf.py

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,12 @@ Changelog
 Version 0.2
 ===========
 
+Version 0.2.2
+-------------
+
+* Added additional checks to determine if a branch or tag contains both the Sphinx source directory and the :file:`conf.py` file. If that's not the case, that branch or tag is skipped automatically and not copied to the temporary directory. (`#9 <issue9_>`_)
+
+
 Version 0.2.1
 -------------
 
@@ -36,3 +42,4 @@ Version 0.1.0
 
 .. _issue4: https://github.com/Holzhaus/sphinx-multiversion/issues/4
 .. _issue7: https://github.com/Holzhaus/sphinx-multiversion/issues/7
+.. _issue9: https://github.com/Holzhaus/sphinx-multiversion/issues/9

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import time
 
 author = "Jan Holthuis"
 project = "sphinx-multiversion"
-release = "0.2.1"
+release = "0.2.2"
 version = "0.2"
 copyright = "{}, {}".format(time.strftime("%Y"), author)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -33,8 +33,7 @@ You can override all of these values inside your :file:`conf.py`.
 
 .. note::
 
-    You can check which tags/branches are matched by running ``sphinx-multiversion`` with the ``--dump-metadata`` flag.
-
+    You can check which tags/branches are matched by running ``sphinx-multiversion`` with the ``--dump-metadata`` flag. Branches or tags that don't contain both the sphinx source directory and the :file:`conf.py` file will be skipped automatically.
 
 Tag/Branch/Remote whitelists
 ============================

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://holzhaus.github.io/sphinx-multiversion/",
-    version="0.2.1",
+    version="0.2.2",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -86,7 +86,9 @@ def file_exists(gitroot, refname, filename):
         "-e",
         "{}:{}".format(refname, filename),
     )
-    proc = subprocess.run(cmd, cwd=gitroot, capture_output=True)
+    proc = subprocess.run(
+        cmd, cwd=gitroot, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
     return proc.returncode == 0
 
 

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -48,7 +48,8 @@ def get_all_refs(gitroot):
         yield GitRef(name, commit, source, is_remote, refname, creatordate)
 
 
-def get_refs(gitroot, tag_whitelist, branch_whitelist, remote_whitelist, files=()):
+def get_refs(gitroot, tag_whitelist, branch_whitelist, remote_whitelist,
+             files=()):
     for ref in get_all_refs(gitroot):
         if ref.source == "tags":
             if tag_whitelist is None or not re.match(tag_whitelist, ref.name):

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -48,7 +48,7 @@ def get_all_refs(gitroot):
         yield GitRef(name, commit, source, is_remote, refname, creatordate)
 
 
-def get_refs(gitroot, tag_whitelist, branch_whitelist, remote_whitelist):
+def get_refs(gitroot, tag_whitelist, branch_whitelist, remote_whitelist, files=()):
     for ref in get_all_refs(gitroot):
         if ref.source == "tags":
             if tag_whitelist is None or not re.match(tag_whitelist, ref.name):
@@ -69,7 +69,22 @@ def get_refs(gitroot, tag_whitelist, branch_whitelist, remote_whitelist):
         else:
             continue
 
+        if not all(file_exists(gitroot, ref.name, filename)
+                   for filename in files):
+            continue
+
         yield ref
+
+
+def file_exists(gitroot, refname, filename):
+    cmd = (
+        "git",
+        "cat-file",
+        "-e",
+        "{}:{}".format(refname, filename),
+    )
+    proc = subprocess.run(cmd, cwd=gitroot, capture_output=True)
+    return proc.returncode == 0
 
 
 def copy_tree(src, dst, reference, sourcepath="."):

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -48,8 +48,9 @@ def get_all_refs(gitroot):
         yield GitRef(name, commit, source, is_remote, refname, creatordate)
 
 
-def get_refs(gitroot, tag_whitelist, branch_whitelist, remote_whitelist,
-             files=()):
+def get_refs(
+    gitroot, tag_whitelist, branch_whitelist, remote_whitelist, files=()
+):
     for ref in get_all_refs(gitroot):
         if ref.source == "tags":
             if tag_whitelist is None or not re.match(tag_whitelist, ref.name):
@@ -70,8 +71,9 @@ def get_refs(gitroot, tag_whitelist, branch_whitelist, remote_whitelist,
         else:
             continue
 
-        if not all(file_exists(gitroot, ref.name, filename)
-                   for filename in files):
+        if not all(
+            file_exists(gitroot, ref.name, filename) for filename in files
+        ):
             continue
 
         yield ref

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -91,13 +91,22 @@ def main(argv=None):
     config.pre_init_values()
     config.init_values()
 
-    # Get git references
+    # Get relative paths to root of git repository
     gitroot = pathlib.Path(".").resolve()
+    sourcedir = os.path.relpath(args.sourcedir, str(gitroot))
+    if args.confdir:
+        confdir = os.path.relpath(args.confdir, str(gitroot))
+    else:
+        confdir = sourcedir
+    conffile = os.path.join(confdir, "conf.py")
+
+    # Get git references
     gitrefs = git.get_refs(
         str(gitroot),
         config.smv_tag_whitelist,
         config.smv_branch_whitelist,
         config.smv_remote_whitelist,
+        files=(sourcedir, conffile),
     )
 
     # Order git refs
@@ -107,13 +116,6 @@ def main(argv=None):
         gitrefs = sorted(gitrefs, key=lambda x: (x.is_remote, *x))
 
     logger = logging.getLogger(__name__)
-
-    # Get Sourcedir
-    sourcedir = os.path.relpath(args.sourcedir, str(gitroot))
-    if args.confdir:
-        confdir = os.path.relpath(args.confdir, str(gitroot))
-    else:
-        confdir = sourcedir
 
     with tempfile.TemporaryDirectory() as tmp:
         # Generate Metadata


### PR DESCRIPTION
Filters out branches that don't contain the source directory or `conf.py`. This should be less resource-intensive compared to PR #8.