### PR TITLE
add slash if doc is in this folder

### DIFF
--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -118,6 +118,8 @@ def get_refs(
 
 
 def file_exists(gitroot, refname, filename):
+    if filename == '.':
+        filename += '/'
     cmd = (
         "git",
         "cat-file",

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -118,6 +118,7 @@ def get_refs(
 
 
 def file_exists(gitroot, refname, filename):
+    # Correct path in the case of documentation is located in the local folder.
     if filename == '.':
         filename += '/'
     cmd = (


### PR DESCRIPTION
For a documentation project the sphinx files are not necessarily located in a folder, and can be found in the root folder itself.

In version 0.2.3 the following command fails:
```
$ sphinx-multiversion -D smv_remote_whitelist='^.*$' -D smv_current_version=master ./ public/
No matching refs found!
```
The trailing slash is deleted in the processing, but is required for 'git cat-file' command if the doc folder is '.'

This patch proposes to add a slash to filename == '.'  during the file_exists function.