### PR TITLE
git: Skip "git cat-file" check if filename is "."

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,12 @@ Changelog
 Version 0.2
 ===========
 
+Version 0.2.4 (unreleased)
+--------------------------
+
+* Skip file existence check for the :file:`.` directory. This fixes an issue if the configuration or source directory is in the local path but reported as missing, because ``git cat-file -e`` always reports an error in that case. (`#12 <issue12_>`_)
+
+
 Version 0.2.3
 -------------
 
@@ -51,3 +57,4 @@ Version 0.1.0
 .. _issue4: https://github.com/Holzhaus/sphinx-multiversion/issues/4
 .. _issue7: https://github.com/Holzhaus/sphinx-multiversion/issues/7
 .. _issue9: https://github.com/Holzhaus/sphinx-multiversion/issues/9
+.. _issue12: https://github.com/Holzhaus/sphinx-multiversion/issues/12

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import time
 
 author = "Jan Holthuis"
 project = "sphinx-multiversion"
-release = "0.2.3"
+release = "0.2.4"
 version = "0.2"
 copyright = "{}, {}".format(time.strftime("%Y"), author)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://holzhaus.github.io/sphinx-multiversion/",
-    version="0.2.3",
+    version="0.2.4",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -104,7 +104,8 @@ def get_refs(
         missing_files = [
             filename
             for filename in files
-            if not file_exists(gitroot, ref.refname, filename)
+            if filename != "."
+            and not file_exists(gitroot, ref.refname, filename)
         ]
         if missing_files:
             logger.debug(


### PR DESCRIPTION
Apparently, "git cat-file -e somebranch:." returns an error. Since the
local directory (".") always exists anyway, we can just skip the file_exists
check in that case.