### PR TITLE
Fix file_exists helper under Windows

### DIFF
--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -2,6 +2,7 @@
 import collections
 import datetime
 import logging
+import os
 import re
 import subprocess
 import tarfile
@@ -119,6 +120,10 @@ def get_refs(
 
 
 def file_exists(gitroot, refname, filename):
+    if os.sep != "/":
+        # Git requires / path sep, make sure we use that
+        filename = filename.replace(os.sep, "/")
+
     cmd = (
         "git",
         "cat-file",


### PR DESCRIPTION
Turns out git cat-file uses / as path separator and thus would not
be able to find docs\conf.py on a Windows system.

Fixes #18