### PR TITLE
Always use original conf.py file

### DIFF
--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -189,7 +189,7 @@ def main(argv=None):
                 "outputdir": os.path.join(
                     os.path.abspath(args.outputdir), outputdir
                 ),
-                "confdir": confpath,
+                "confdir": confdir_absolute,
                 "docnames": list(project.discover()),
             }
 


### PR DESCRIPTION
In an attempt to fix #11, the patch provided in #13 actually broke
support for repositories that did not always had sphinx-multiversion
configured. This commit restores the original behaviour of always using
the config file passed to `sphinx-multiversion`, not the config file
from the git revision that is currently built.

Resolves #15.