### PR TITLE
Fix detection of git submodules

### DIFF
--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -21,9 +21,13 @@ def get_toplevel_path(cwd=None):
         "git",
         "rev-parse",
         "--show-toplevel",
+        "--show-superproject-working-tree",
     )
     output = subprocess.check_output(cmd, cwd=cwd).decode()
-    return output.rstrip("\n")
+    # If this is a git submodule of a super project then we'll have two lines
+    # of output, otherwise one. Since the superproject flag is second in the
+    # command above the superproject will always be the last line if present.
+    return output.split()[-1]
 
 
 def get_all_refs(gitroot):


### PR DESCRIPTION
Closes #48 

This uses the "--show-superproject-working-tree" flag in the `get_toplevel_path` call to git to add an additional line of output if the current directory is a git submodule of another project (a super project). When provided along with the `--show-toplevel` flag and when in a git submodule you will get two lines of output. One for the git submodule root and one for the super project root (note: order of the flags in the command determine the order of the lines in the output). If it isn't a git submodule then there will only ever be one line of output.