### PR TITLE
Version-dependent rst_prolog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
     license="BSD",
     packages=["sphinx_multiversion"],
     entry_points={
-        "console_scripts": ["sphinx-multiversion=sphinx_multiversion:main",],
+        "console_scripts": [
+            "sphinx-multiversion=sphinx_multiversion:main",
+        ],
     },
 )

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -10,7 +10,14 @@ import tempfile
 
 GitRef = collections.namedtuple(
     "VersionRef",
-    ["name", "commit", "source", "is_remote", "refname", "creatordate",],
+    [
+        "name",
+        "commit",
+        "source",
+        "is_remote",
+        "refname",
+        "creatordate",
+    ],
 )
 
 logger = logging.getLogger(__name__)

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -274,6 +274,7 @@ def main(argv=None):
                 "name": gitref.name,
                 "version": current_config.version,
                 "release": current_config.release,
+                "rst_prolog": current_config.rst_prolog,
                 "is_released": bool(
                     re.match(config.smv_released_pattern, gitref.refname)
                 ),

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -34,7 +34,8 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
     try:
         with working_dir(confpath):
             current_config = sphinx_config.Config.read(
-                confpath, confoverrides,
+                confpath,
+                confoverrides,
             )
 
         if add_defaults:
@@ -250,7 +251,8 @@ def main(argv=None):
 
             # Ensure that there are not duplicate output dirs
             outputdir = config.smv_outputdir_format.format(
-                ref=gitref, config=current_config,
+                ref=gitref,
+                config=current_config,
             )
             if outputdir in outputdirs:
                 logger.warning(

--- a/sphinx_multiversion/sphinx.py
+++ b/sphinx_multiversion/sphinx.py
@@ -20,7 +20,14 @@ DEFAULT_RELEASED_PATTERN = r"^tags/.*$"
 DEFAULT_OUTPUTDIR_FORMAT = r"{ref.name}"
 
 Version = collections.namedtuple(
-    "Version", ["name", "url", "version", "release", "is_released",]
+    "Version",
+    [
+        "name",
+        "url",
+        "version",
+        "release",
+        "is_released",
+    ],
 )
 
 

--- a/sphinx_multiversion/sphinx.py
+++ b/sphinx_multiversion/sphinx.py
@@ -175,6 +175,7 @@ def config_inited(app, config):
     old_config.init_values()
     config.version = data["version"]
     config.release = data["release"]
+    config.rst_prolog = data["rst_prolog"]
     config.today = old_config.today
     if not config.today:
         config.today = sphinx_i18n.format_date(


### PR DESCRIPTION
We use https://github.com/adamtheturtle/sphinx-substitution-extensions to substiture release version into the code snippets and for that we need to take `rst_prolog` parameter from `conf.py` that is in branches/tags, not the current one. 
This patch solves it.