### PR TITLE
Use the latest_version in the latest_version example

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -151,7 +151,7 @@ Other Variables
 
     .. code-block:: jinja
 
-        <h3>Latest Version: {{ current_version.name }}</h3>
+        <h3>Latest Version: {{ latest_version.name }}</h3>
 
 
 .. _sphinx_context: http://www.sphinx-doc.org/en/stable/config.html?highlight=context#confval-html_context


### PR DESCRIPTION
It looks like a copy and paste typo to show using the current_version as an example for the latest version