### PR TITLE
Fixup Version Banner usage so it works by default

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -84,11 +84,11 @@ List releases and development versions separately
 Version Banners
 ===============
 
-You can also add version banners to your theme, for example:
+You can also add version banners to your theme, for example create a template file page.html in the templates directory:
 
 .. code-block:: html
 
-    {% extends "page.html" %}
+    {% extends "!page.html" %}
     {% block body %}
     {% if current_version and latest_version and current_version != latest_version %}
     <p>
@@ -100,7 +100,7 @@ You can also add version banners to your theme, for example:
         You're reading the documentation for a development version.
         For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
         {% endif %}
-      <strong>
+      </strong>
     </p>
     {% endif %}
     {{ super() }}


### PR DESCRIPTION
* Clarify the filename has to match the extended template, otherwise it never took effect.
* The exclamation point is necessary for it to extend the underlying html template, which is likely what a person following this tutorial is doing. 
  Otherwise it infinitely recurses with the error: `Reason: RecursionError('maximum recursion depth exceeded in comparison')`
* Close the strong tag correctly.

These are the things that I had to do to get this to work on my system With sphinx v3.2.1 in a python3 virtualenv. I don't know about other versions etc. But this is what was necessary to avoid the errors.

Most of this is from reading: https://www.sphinx-doc.org/en/master/templating.html