### PR TITLE
applying patch from black linter errors for CI to pass

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
     license="BSD",
     packages=["sphinx_multiversion"],
     entry_points={
-        "console_scripts": ["sphinx-multiversion=sphinx_multiversion:main",],
+        "console_scripts": [
+            "sphinx-multiversion=sphinx_multiversion:main",
+        ],
     },
 )

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -10,7 +10,14 @@ import tempfile
 
 GitRef = collections.namedtuple(
     "VersionRef",
-    ["name", "commit", "source", "is_remote", "refname", "creatordate",],
+    [
+        "name",
+        "commit",
+        "source",
+        "is_remote",
+        "refname",
+        "creatordate",
+    ],
 )
 
 logger = logging.getLogger(__name__)

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -34,7 +34,8 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
     try:
         with working_dir(confpath):
             current_config = sphinx_config.Config.read(
-                confpath, confoverrides,
+                confpath,
+                confoverrides,
             )
 
         if add_defaults:
@@ -250,7 +251,8 @@ def main(argv=None):
 
             # Ensure that there are not duplicate output dirs
             outputdir = config.smv_outputdir_format.format(
-                ref=gitref, config=current_config,
+                ref=gitref,
+                config=current_config,
             )
             if outputdir in outputdirs:
                 logger.warning(

--- a/sphinx_multiversion/sphinx.py
+++ b/sphinx_multiversion/sphinx.py
@@ -20,7 +20,14 @@ DEFAULT_RELEASED_PATTERN = r"^tags/.*$"
 DEFAULT_OUTPUTDIR_FORMAT = r"{ref.name}"
 
 Version = collections.namedtuple(
-    "Version", ["name", "url", "version", "release", "is_released",]
+    "Version",
+    [
+        "name",
+        "url",
+        "version",
+        "release",
+        "is_released",
+    ],
 )
 
 


### PR DESCRIPTION
Currently master is failing CI and consequently all other PRs are also failing CI. This is applying the formatting diff which is printed in the console output to attempt to resolve the linter errors.