### PR TITLE
Add smv_prebuild_command config option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,6 +81,14 @@ Here are some examples:
 
         git for-each-ref --format "%(refname)"
 
+Prebuild command
+================
+
+In some cases it may be necessary to run a command in the checked out directory before building with sphinx. For example if you are using ``sphinx-apidoc`` to generate the autodoc api source files.
+
+For example:
+
+    smv_prebuild_command = "sphinx-apidoc -o docs/api mymodule"
 
 Output Directory Format
 =======================

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,10 +81,12 @@ Here are some examples:
 
         git for-each-ref --format "%(refname)"
 
-Prebuild command
+Pre and post-build command
 ================
 
-In some cases it may be necessary to run a command in the checked out directory before building with sphinx. For example if you are using ``sphinx-apidoc`` to generate the autodoc api source files.
+In some cases it may be necessary to run a command in the checked out directory before or after building with sphinx. For example if you are using ``sphinx-apidoc`` to generate the autodoc api source files.
+
+The options ``smv_prebuild_command`` and ``smv_postbuild_command`` are provided.
 
 For example:
 

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -94,6 +94,7 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
             )
             current_config.add("smv_prefer_remote_refs", False, "html", bool)
             current_config.add("smv_prebuild_command", "", "html", str)
+            current_config.add("smv_postbuild_command", "", "html", str)
         current_config.pre_init_values()
         current_config.init_values()
     except Exception as err:
@@ -386,5 +387,14 @@ def main(argv=None):
                 }
             )
             subprocess.check_call(cmd, cwd=current_cwd, env=env)
+
+            if config.smv_postbuild_command != "":
+                logger.debug(
+                    "Running postbuild command: %r",
+                    config.smv_postbuild_command,
+                )
+                subprocess.check_call(
+                    config.smv_postbuild_command, cwd=current_cwd, shell=True
+                )
 
     return 0

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -93,6 +93,7 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
                 str,
             )
             current_config.add("smv_prefer_remote_refs", False, "html", bool)
+            current_config.add("smv_prebuild_command", "", "html", str)
         current_config.pre_init_values()
         current_config.init_values()
     except Exception as err:
@@ -355,6 +356,15 @@ def main(argv=None):
                     *args.filenames,
                 ]
             )
+            current_cwd = os.path.join(data["basedir"], cwd_relative)
+            if config.smv_prebuild_command != "":
+                logger.debug(
+                    "Running prebuild command: %r", config.smv_prebuild_command
+                )
+                subprocess.check_call(
+                    config.smv_prebuild_command, cwd=current_cwd, shell=True
+                )
+
             logger.debug("Running sphinx-build with args: %r", current_argv)
             cmd = (
                 sys.executable,
@@ -363,7 +373,7 @@ def main(argv=None):
                 "sphinx",
                 *current_argv,
             )
-            current_cwd = os.path.join(data["basedir"], cwd_relative)
+
             env = os.environ.copy()
             env.update(
                 {


### PR DESCRIPTION
Can be used to run a command in the checked out director before building
with sphinx.