### PR TITLE
setup.py: Add sphinx-rtd-theme package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sphinx
+sphinx-rtd-theme

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email="holthuis.jan@googlemail.com",
     url="https://holzhaus.github.io/sphinx-multiversion/",
     version="0.2.4",
-    install_requires=["sphinx >= 2.1"],
+    install_requires=["sphinx >= 2.1", "sphinx-rtd-theme"],
     license="BSD",
     packages=["sphinx_multiversion"],
     entry_points={


### PR DESCRIPTION
`sphinx-multiversion` gives the below error when `sphinx-rtd-theme` package is not present:

```
Failed load config for refs/tags/v0.2 from /tmp/tmpxu2bycw5/5a6e6147cd15c6552c72dadd35e6b44ab8ae7a3c/docs/source
Failed load config for refs/tags/v0.2.1 from /tmp/tmpxu2bycw5/59d6100ea24a0c2dad87d2202e3f3455c0a8f589/docs/source
Failed load config for refs/tags/v0.3 from /tmp/tmpxu2bycw5/42b7d8000e9227a5e25c91a1039312331c16492c/docs/source
```

After I installed `sphinx-rtd-theme`, the above error got resolved. So I believe `sphinx-rtd-theme` should be present in `setup.py` file.

This should also resolve #57. I faced a similar issue on GitLab CI, where the `sphinx-multiversion` build was failing and producing the above error. After I installed `sphinx-rtd-theme` in GitLab CI, the build ran fine without any errors.