### PR TITLE
Fix sphinx subprocess source-path argument

### DIFF
--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -268,9 +268,8 @@ def main(argv=None):
             if isinstance(source_suffixes, str):
                 source_suffixes = [current_config.source_suffix]
 
-            current_sourcedir = os.path.join(repopath, sourcedir)
             project = sphinx_project.Project(
-                current_sourcedir, source_suffixes
+                sourcedir, source_suffixes
             )
             metadata[gitref.name] = {
                 "name": gitref.name,
@@ -283,7 +282,7 @@ def main(argv=None):
                 "source": gitref.source,
                 "creatordate": gitref.creatordate.strftime(sphinx.DATE_FMT),
                 "basedir": repopath,
-                "sourcedir": current_sourcedir,
+                "sourcedir": sourcedir,
                 "outputdir": os.path.join(
                     os.path.abspath(args.outputdir), outputdir
                 ),


### PR DESCRIPTION
fixes #76

Using an absolute source path prevents extensions like sphinxcontrib-kroki to work properly.

Since sphinx is running in it's own subprocess, the absolute path to the source dir is not required anymore.