### PR TITLE
Add `smv_refs_filter_fn` config option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,6 +29,9 @@ This is what the default configuration looks like:
     # Determines whether remote or local git branches/tags are preferred if their output dirs conflict
     smv_prefer_remote_refs = False
 
+    # Callable for transforming the list of matching refs (set to None to do no transformation)
+    smv_refs_filter_fn = None
+
 You can override all of these values inside your :file:`conf.py`.
 
 .. note::
@@ -104,6 +107,32 @@ Here are some examples:
 .. seealso::
 
     Have a look at `PyFormat <python_format_>`_ for information how to use new-style Python formatting.
+
+
+Arbitrary filtering of git refs
+===============================
+
+In some cases the regexes above may be insufficient to determine which git refs to build, for instance to build only the most recent N builds. For those cases the ``smv_refs_filter_fn`` setting may be set to a Python function which filters, sorts, and transforms the list of matching git refs.
+
+For example:
+
+.. code-block:: python
+
+    # Keep main and the most recent 5 releases
+    def git_ref_filter(git_refs):
+      main_ref = None
+      release_refs = []
+      for git_ref in git_refs:
+        if git_ref.name == "main":
+          main_ref = git_ref
+        elif "release" in git_ref.name:
+          release_refs.append(git_ref)
+
+      release_refs = sorted(release_refs, key=git_ref_to_semver)[-5:]
+
+      return [main_ref] + release_refs
+
+    smv_refs_filter_fn = git_ref_filter
 
 
 Overriding Configuration Variables

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -12,6 +12,7 @@ import string
 import subprocess
 import sys
 import tempfile
+from typing import Optional, Callable
 
 from sphinx import config as sphinx_config
 from sphinx import project as sphinx_project
@@ -67,6 +68,9 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
                 str,
             )
             current_config.add("smv_prefer_remote_refs", False, "html", bool)
+            current_config.add(
+                "smv_refs_filter_fn", None, "html", Optional[Callable]
+            )
         current_config.pre_init_values()
         current_config.init_values()
     except Exception as err:
@@ -76,14 +80,21 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
     q.put(current_config)
 
 
-def load_sphinx_config(confpath, confoverrides, add_defaults=False):
+def load_sphinx_config(
+    confpath, confoverrides, add_defaults=False, in_process=False
+):
     q = multiprocessing.Queue()
-    proc = multiprocessing.Process(
-        target=load_sphinx_config_worker,
-        args=(q, confpath, confoverrides, add_defaults),
-    )
-    proc.start()
-    proc.join()
+    target = load_sphinx_config_worker
+    args = (q, confpath, confoverrides, add_defaults)
+    if in_process:
+        target(*args)
+    else:
+        proc = multiprocessing.Process(
+            target=target,
+            args=args,
+        )
+        proc.start()
+        proc.join()
     result = q.get_nowait()
     if isinstance(result, Exception):
         raise result
@@ -181,7 +192,10 @@ def main(argv=None):
 
     # Parse config
     config = load_sphinx_config(
-        confdir_absolute, confoverrides, add_defaults=True
+        confdir_absolute,
+        confoverrides,
+        add_defaults=True,
+        in_process=True,
     )
 
     # Get relative paths to root of git repository
@@ -217,6 +231,9 @@ def main(argv=None):
         gitrefs = sorted(gitrefs, key=lambda x: (not x.is_remote, *x))
     else:
         gitrefs = sorted(gitrefs, key=lambda x: (x.is_remote, *x))
+
+    if config.smv_refs_filter_fn is not None:
+        gitrefs = config.smv_refs_filter_fn(gitrefs)
 
     logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Regexes are simple and easily transferable, but have limited expressivity. We've found that the regex options cannot express all the restrictions we may want, and even where they can be expressed as a regex they're often restrictive. For instance we want to limit the number of old release tags that we still build the docs for, and we currently do that with [a regex which attempts to match a minimum semver value](https://github.com/microsoft/CCF/blob/ebf732a8a01bd675f5d647fd1a62371fd1ebe9d3/doc/conf.py#L202).

It would be more expressive if we could simply pass a function which looks at each gitref and decides if we want to build docs for it. Additionally, this function can sort the gitrefs (so we don't need to try and express the order in a template later), and rewrite the other metadata if required (I was hoping to set an `is_release` bool here, but it turns out that's set later).

This adds a new config option which takes a callable to transform (or, I guess, entirely reconstruct!) the retrieved gitrefs. The only non-obvious change is that I had to make `load_sphinx_config` execute in-process for the first call, so that the callable is correctly retained and not lost when the loading process closes. This is a partial reversion of #30, but I believe its safe - the separate process is still used to parse the config for all the _other_ configs, ensuring that they get the correct local `conf.py`.