### PR TITLE
Fix to follow the FAQ. Use the `conf.py` file from your currently checked out branch.

### DIFF
--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -12,6 +12,7 @@ import string
 import subprocess
 import sys
 import tempfile
+import shutil
 
 from sphinx import config as sphinx_config
 from sphinx import project as sphinx_project
@@ -240,6 +241,7 @@ def main(argv=None):
             # Find config
             confpath = os.path.join(repopath, confdir)
             try:
+                shutil.copy(os.path.join(confdir_absolute, "conf.py"), confpath)
                 current_config = load_sphinx_config(confpath, confoverrides)
             except (OSError, sphinx_config.ConfigError):
                 logger.error(


### PR DESCRIPTION
This is stated as how things work in the [FAQ](https://holzhaus.github.io/sphinx-multiversion/master/faq.html).

> Do I need to make changes to old branches or tags?
No, you don’t. sphinx-multiversion will always use the conf.py file from your currently checked out branch.

Use the `conf.py` file from your currently checked out branch when loading config options from other branches/tags. This change fixed an instance of the `Failed load config for %s from %s` for me after I changed my `conf.py` file. 