### PR TITLE
fix: update Config.read() signature (overrides, tags)

### DIFF
--- a/.pre-commit/version_check.py
+++ b/.pre-commit/version_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/sphinx_multiversion/__init__.py
+++ b/sphinx_multiversion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/sphinx_multiversion/__main__.py
+++ b/sphinx_multiversion/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -41,6 +41,7 @@ import tempfile
 
 from sphinx import config as sphinx_config
 from sphinx import project as sphinx_project
+from sphinx.util.tags import Tags
 
 from . import sphinx
 from . import git
@@ -61,7 +62,8 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
         with working_dir(confpath):
             current_config = sphinx_config.Config.read(
                 confpath,
-                confoverrides,
+                overrides=confoverrides,
+                tags=Tags(),
             )
 
         if add_defaults:

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/sphinx_multiversion/sphinx.py
+++ b/sphinx_multiversion/sphinx.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -204,7 +204,9 @@ def config_inited(app, config):
     app.connect("html-page-context", html_page_context)
 
     # Restore config values
-    old_config = sphinx_config.Config.read(data["confdir"], overrides={}, tags=Tags())
+    old_config = sphinx_config.Config.read(
+        data["confdir"], overrides={}, tags=Tags()
+    )
     old_config.pre_init_values()
     old_config.init_values()
     config.version = data["version"]

--- a/sphinx_multiversion/sphinx.py
+++ b/sphinx_multiversion/sphinx.py
@@ -35,6 +35,7 @@ import posixpath
 from sphinx import config as sphinx_config
 from sphinx.util import i18n as sphinx_i18n
 from sphinx.locale import _
+from sphinx.util.tags import Tags
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +204,7 @@ def config_inited(app, config):
     app.connect("html-page-context", html_page_context)
 
     # Restore config values
-    old_config = sphinx_config.Config.read(data["confdir"])
+    old_config = sphinx_config.Config.read(data["confdir"], overrides={}, tags=Tags())
     old_config.pre_init_values()
     old_config.init_values()
     config.version = data["version"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2025 Jan Holthuis <jan.holthuis@rub.de>
+# Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
### Purpose
<!--
Explain the **motivation** for making this change. What existing problem does
the pull request solve? This could be a short summary of the motivating issue.


You may remove this if you're fixing a typo.
-->

This PR fixes an incompatibility with newer **Sphinx versions (≥ 9)** when using `sphinx-multiversion` on Python 3.11+.

Starting from **Sphinx 8.2.0**, **Python 3.11**+ is required.
`sphinx-multiversion` officially supports **Python 8–12**, but it currently does **not restrict the Sphinx version**
As a result, when users run `sphinx-multiversion` on Python 3.11 or newer, **Sphinx 9+ is automatically installed**

In Sphinx 9, the signature of `Config.read()` requires keyword arguments:
However, `sphinx-multiversion` was still calling it using the old positional-style API, causing runtime errors when used with Sphinx ≥ 9 (see #201).

Resolves #201  <!-- associate the motivating issue -->


### Solution Sketch
<!--
Outline the design decisions leading to this very change set.
-->

This PR updates all calls to `Config.read()` to:

* Pass arguments explicitly as **keyword arguments**
* Provide a `Tags()` instance explicitly

The parameter names (`overrides`, `tags`) are consistent across **Sphinx 7 through 9**, so using keyword arguments is safe and compatible across **Python 3.8–3.12**

* Avoids introducing conditional logic based on Sphinx versions
* Maintains backward compatibility with older supported Sphinx releases
* Fixes the issue without tightening dependency constraints
* Aligns with the current Sphinx public API

